### PR TITLE
Fix error while trying to loading data on starting fiware-orion image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     command: -dbhost mongo-db -logLevel DEBUG
     healthcheck:
       test: curl --fail -s http://orion:${ORION_PORT}/version || exit 1
+      interval: 1s
 
   # Tutorial acts as a series of dummy IoT Sensors over HTTP
   tutorial:

--- a/services
+++ b/services
@@ -25,9 +25,15 @@ stoppingContainers () {
 	docker-compose --log-level ERROR -p fiware down -v --remove-orphans
 }
 
+displayServices () {
+	echo ""
+	docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" --filter name=fiware-*
+	echo ""
+}
+
 waitForOrion () {
 	echo -e "\n⏳ Waiting for \033[1;34mOrion\033[0m to be available\n"
-	while [ `docker run --network fiware_default --rm curlimages/curl -s -o /dev/null -w %{http_code} 'http://orion:1026/version'` -eq 000 ]
+	while ! [ `docker inspect --format='{{.State.Health.Status}}' fiware-orion` == "healthy" ]
 	do 
 	  echo -e "Context Broker HTTP state: " `curl -s -o /dev/null -w %{http_code} 'http://localhost:1026/version'` " (waiting for 200)"
 	  sleep 1
@@ -45,7 +51,9 @@ case "${command}" in
 		echo -e "- \033[1mTutorial\033[0m acts as a series of dummy IoT Sensors over HTTP"
 		echo ""
 		docker-compose --log-level ERROR -p fiware up -d --remove-orphans
+		waitForOrion
 		loadData
+		displayServices
 		echo -e "Now open \033[4mhttp://localhost:3000/device/monitor\033[0m"
 		;;
 	"stop")


### PR DESCRIPTION
loadData function is called before fiware-orion is in healthy state, resulting in a unexpected termination of the script while executing `./services start`.

Added an additional check waiting for the fiware-orion image to become in healthy state. 

Added displayServices function at the end (as other previous tutorials)